### PR TITLE
Use python3 per default

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -7,4 +7,4 @@ check_mk::client::library_item_path: '/usr/lib/check_mk_agent'
 check_mk::client::library_item_default_mode: '0755'
 
 check_mk::server::required_packages:
-  - 'python-rrdtool'
+  - 'python3-rrdtool'

--- a/data/os/Debian/20.04.yaml
+++ b/data/os/Debian/20.04.yaml
@@ -1,3 +1,0 @@
----
-check_mk::server::required_packages:
-  - 'python3-rrdtool'

--- a/data/os/Debian/22.04.yaml
+++ b/data/os/Debian/22.04.yaml
@@ -1,3 +1,0 @@
----
-check_mk::server::required_packages:
-  - 'python3-rrdtool'


### PR DESCRIPTION
This implicitly drops Ubuntu 18.04 support